### PR TITLE
google-oauth2 fix: force https to prevent edge case session loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 env/
 venv/
+myhacks/
 *.swp
 *.pyc
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -295,6 +295,13 @@ OAUTH_PROVIDERS = {
 
     }
 }
+
+'''
+addresses edge case where user using reverse proxy (nginx) for auth loses session because
+of the shift from https -> http, losing essential headers in the process.  
+'''
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
+
 SOCIAL_AUTH_URL_NAMESPACE = "social"
 SOCIAL_AUTH_USER_FIELDS = ['email', 'first_name', 'last_name']
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = env('GOOGLE_KEY')


### PR DESCRIPTION
Theorized but not re-created: certain browser permissions might cause edge case users to lose the session data over oauth due to dropped headers when passing thru the reverse proxy (nginx) resulting in lossy "conversion" of https -> http.